### PR TITLE
style: 네비게이션 프로필 아이콘 위치 조정

### DIFF
--- a/public/component/common/header/navigator/navigator.css
+++ b/public/component/common/header/navigator/navigator.css
@@ -14,17 +14,11 @@
     flex: 1;
   }
 
-  .navigator_center {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 10;
-  }
-
   .navigator_right {
     flex: 1;
     display: flex;
     justify-content: flex-end;
+    padding-right: 100px;
   }
   
   /* 로고 */


### PR DESCRIPTION
## 변경사항
- 네비게이션 프로필 아이콘 위치 조정
- navigator_center 절대 위치 제거
- navigator_right에 padding-right: 100px 추가

## 수정 내용
- `navigator.css`에서 `.navigator_center`의 절대 위치 스타일 제거
- `.navigator_right`에 `padding-right: 100px;` 추가하여 프로필 아이콘이 오른쪽에서 100px 떨어진 위치에 배치되도록 조정