### PR TITLE
fix: 게시글 상세페이지 댓글 작성자 프로필 이미지 표시 문제 해결

### DIFF
--- a/public/component/post/post_detail/comment_wrap/comment_wrap.css
+++ b/public/component/post/post_detail/comment_wrap/comment_wrap.css
@@ -90,6 +90,17 @@
   background: linear-gradient(135deg, rgba(26, 37, 48, 0.3) 0%, rgba(37, 48, 64, 0.2) 100%);
   flex-shrink: 0;
   border: 1px solid rgba(53, 64, 80, 0.3);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.comment_avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
 }
 
 .comment_info {

--- a/public/component/post/post_detail/comment_wrap/comment_wrap.js
+++ b/public/component/post/post_detail/comment_wrap/comment_wrap.js
@@ -12,7 +12,11 @@ export function renderCommentWrap(container, comments = []) {
             (comment) => `
           <div class="comment_item" data-comment-id="${comment.commentId}">
             <div class="comment_profile">
-              <div class="comment_avatar"></div>
+              <div class="comment_avatar">
+                ${comment.profileImageUrl 
+                  ? `<img src="${comment.profileImageUrl}" alt="${comment.nickname || '작성자'}" onerror="this.style.display='none'; this.parentElement.style.background='linear-gradient(135deg, rgba(26, 37, 48, 0.3) 0%, rgba(37, 48, 64, 0.2) 100%)';" />` 
+                  : ''}
+              </div>
               <div class="comment_info">
                 <div class="comment_header">
                   <span class="comment_author">${comment.nickname || "익명"}</span>


### PR DESCRIPTION
## 변경사항
- 게시글 상세페이지 댓글에 작성자 프로필 이미지가 표시되지 않는 문제 해결

## 수정 내용
- `comment_wrap.js`: 프로필 이미지 표시 로직 추가 (`comment.profileImageUrl` 사용)
- `comment_wrap.css`: 프로필 이미지 스타일 추가 (원형 표시, overflow 처리)
- 이미지가 없거나 로드 실패 시 기본 배경 유지