### PR TITLE
🔧 Develop → Main: 게시글 작성/수정 페이지 레이아웃 통일

### DIFF
--- a/public/pages/post/post_create/post_create.css
+++ b/public/pages/post/post_create/post_create.css
@@ -1,14 +1,22 @@
-body {
-    background: linear-gradient(135deg, #0F161E 0%, #1A2530 30%, #253040 60%, #0F161E 100%);
+/* postCreate 페이지 전용 스타일 */
+
+/* 전역 리셋 */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  
+  body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-        'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-        sans-serif;
+      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+      sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    min-height: 100vh;
-}
-
-.wrap {
+  }
+  
+  /* 전체 래퍼 */
+  .wrap {
     min-height: 100vh;
     position: relative;
     overflow: hidden;
@@ -20,6 +28,7 @@ body {
     background-repeat: no-repeat;
 }
 
+/* 헤더 */
 .header {
     position: sticky;
     top: 0;
@@ -27,15 +36,22 @@ body {
     background: rgba(15, 22, 30, 0.8);
     backdrop-filter: blur(10px);
     box-shadow: 0 2px 10px rgba(26, 37, 48, 0.2);
-    border-bottom: 1px solid rgba(53, 64, 80, 0.2);
+    border-bottom: 1px solid rgba(37, 48, 64, 0.2);
 }
 
+/* 컨테이너 */
 .container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 40px 20px;
+    width: 100%;
+    padding-top: 20px;
     position: relative;
     z-index: 1;
+}
+
+.content {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 20px;
 }
 
 .post_create_wrap {
@@ -184,6 +200,8 @@ body {
     border-color: rgba(64, 74, 85, 0.5);
     box-shadow: 0 0 20px rgba(53, 64, 80, 0.3);
 }
+
+  /* 푸터는 footer_inner.css에서 관리 */
 
 /* 반응형 디자인 */
 @media (max-width: 768px) {

--- a/public/pages/post/post_create/post_create.html
+++ b/public/pages/post/post_create/post_create.html
@@ -8,16 +8,19 @@
 
     <link rel="stylesheet" href="../../../component/common/header/navigator/navigator.css">
     <link rel="stylesheet" href="/pages/post/post_create/post_create.css">
+
     <link rel="stylesheet" href="../../../component/common/footer/footer_inner.css">
 
+
     <script type="module" src="/pages/post/post_create/post_create.js" defer></script>
-</head>
+
 
 <body>
     <div class="wrap">
         <header id="header" class="header" role="nav"></header>
-        <main id="container" class="container">
-            <div class="post_create_wrap">
+        <div id="container" class="container">
+            <div class="content">
+                <div class="post_create_wrap">
                 <h1 class="page_title">새 게시글 작성</h1>
 
                 <div class="form_group">
@@ -42,9 +45,11 @@
                 </div>
 
                 <button class="btn_submit">등록</button>
+                </div>
             </div>
-        </main>
-        <footer id="footer" class="footer"></footer>
+        </div>
+
+        <div id="footer" class="footer"></div>
     </div>
 </body>
 

--- a/public/pages/post/post_modify/post_modify.css
+++ b/public/pages/post/post_modify/post_modify.css
@@ -1,14 +1,22 @@
-body {
-    background: linear-gradient(135deg, #0F161E 0%, #1A2530 30%, #253040 60%, #0F161E 100%);
+/* postModify 페이지 전용 스타일 */
+
+/* 전역 리셋 */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  
+  body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-        'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-        sans-serif;
+      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+      sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    min-height: 100vh;
-}
-
-.wrap {
+  }
+  
+  /* 전체 래퍼 */
+  .wrap {
     min-height: 100vh;
     position: relative;
     overflow: hidden;
@@ -20,6 +28,7 @@ body {
     background-repeat: no-repeat;
 }
 
+/* 헤더 */
 .header {
     position: sticky;
     top: 0;
@@ -27,15 +36,22 @@ body {
     background: rgba(15, 22, 30, 0.8);
     backdrop-filter: blur(10px);
     box-shadow: 0 2px 10px rgba(26, 37, 48, 0.2);
-    border-bottom: 1px solid rgba(53, 64, 80, 0.2);
+    border-bottom: 1px solid rgba(37, 48, 64, 0.2);
 }
 
+/* 컨테이너 */
 .container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 40px 20px;
+    width: 100%;
+    padding-top: 20px;
     position: relative;
     z-index: 1;
+}
+
+.content {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 20px;
 }
 
 .post_modify_wrap {
@@ -184,6 +200,8 @@ body {
     border-color: rgba(64, 74, 85, 0.5);
     box-shadow: 0 0 20px rgba(53, 64, 80, 0.3);
 }
+
+  /* 푸터는 footer_inner.css에서 관리 */
 
 /* 반응형 디자인 */
 @media (max-width: 768px) {

--- a/public/pages/post/post_modify/post_modify.html
+++ b/public/pages/post/post_modify/post_modify.html
@@ -6,19 +6,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>게시글 수정 | Our Universe</title>
 
-    <link rel="stylesheet" href="/styles/global.css">
     <link rel="stylesheet" href="../../../component/common/header/navigator/navigator.css">
     <link rel="stylesheet" href="/pages/post/post_modify/post_modify.css">
+
     <link rel="stylesheet" href="../../../component/common/footer/footer_inner.css">
 
+
     <script type="module" src="/pages/post/post_modify/post_modify.js" defer></script>
-</head>
+
 
 <body>
     <div class="wrap">
         <header id="header" class="header" role="nav"></header>
-        <main id="container" class="container">
-            <div class="post_modify_wrap">
+        <div id="container" class="container">
+            <div class="content">
+                <div class="post_modify_wrap">
                 <h1 class="page_title">게시글 수정</h1>
 
                 <div class="form_group">
@@ -43,9 +45,11 @@
                 </div>
 
                 <button class="btn_submit">수정</button>
+                </div>
             </div>
-        </main>
-        <footer id="footer" class="footer"></footer>
+        </div>
+
+        <div id="footer" class="footer"></div>
     </div>
 </body>
 


### PR DESCRIPTION
## 📋 변경 사항

### 🎨 UI/레이아웃 통일
- 게시글 작성/수정 페이지의 네비게이터 및 레이아웃을 게시글 리스트와 완전히 동일하게 통일
- HTML 구조 통일 ( →  구조)
- CSS 스타일 통일 (전역 리셋, body 스타일 등)
- 중복된  태그 제거

### 📝 상세 내용
- 게시글 작성/수정 페이지의 HTML 구조를 게시글 리스트와 동일하게 변경
- CSS를 게시글 리스트와 동일한 구조로 통일
- 모든 페이지에서 일관된 네비게이터 및 레이아웃 사용

---
이번 업데이트로 게시글 관련 모든 페이지의 UI가 일관되게 통일되었습니다. 🚀